### PR TITLE
Fix Node module type and add DigitalOcean guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,26 @@ continuously:
 ```bash
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```
+
+## Deploying on a DigitalOcean Droplet
+
+To run BizIntelTZ on a fresh Ubuntu Droplet:
+
+1. Install system packages:
+   ```bash
+   sudo apt update && sudo apt install -y python3-pip nodejs npm
+   ```
+2. Clone this repository to the Droplet.
+3. Install dependencies and build the frontend:
+   ```bash
+   pip3 install -r requirements.txt
+   npm install
+   npm run build
+   ```
+4. Start the API server:
+   ```bash
+   python3 main.py
+   ```
+5. Serve the generated `dist/` directory using a web server such as Nginx.
+
+For reliability you can use `pm2` or `systemd` to keep the server running.

--- a/main.py
+++ b/main.py
@@ -460,3 +460,8 @@ if not businesses:
         verified=True,
         claimed=True
     )
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=5000)
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "bizinteltz-frontend",
   "private": true,
   "version": "1.0.0",
-  "type": "module",
   "scripts": {
     "dev": "vite",
     "dev:backend": "node server.js",


### PR DESCRIPTION
## Summary
- remove `type` from `package.json` so the Express backend runs in CommonJS mode
- document deployment on DigitalOcean in README

## Testing
- `python3 -m py_compile main.py`
- `node --check server.js`
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68629f9099d88321a59144e163de4160