### PR TITLE
Fix build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "dev:backend": "node server.js",
     "dev:full": "concurrently \"npm run dev:backend\" \"npm run dev\"",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "start": "npm run dev:full",


### PR DESCRIPTION
## Summary
- remove `tsc` from the `build` script so `npm run build` uses Vite directly

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862aa1415dc8321a1100a7982232f10