### PR TITLE
Add SQLite DB and crawler integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 ## Description
 BizIntelTZ is a FastAPI-based platform that aggregates Tanzanian business data.
-This repository contains a minimal demo implementation with in-memory storage
-for development and testing purposes.
+The application now persists data in a local SQLite database which is
+automatically created on first run. In-memory stores are still used for quick
+access during development.
 
 ## Features
 - Advanced search & filtering
@@ -16,12 +17,15 @@ for development and testing purposes.
 - Analytics tracking
 - Media uploads
 - Lead generation
+- SQLite persistence
+- Website crawling endpoint
 - Basic OAuth2 authentication
 - Create, update & delete businesses
 
 Key endpoints include:
 - `POST /business` to create businesses
 - `POST /scrape` to generate sample data
+- `POST /crawl` to crawl external websites
 - `GET /export` to download a CSV of all businesses
 - `GET /reviews/{biz_id}` to list reviews
 - `POST /claims/approve/{index}` for claim moderation
@@ -31,6 +35,14 @@ Install dependencies and run the application:
 ```bash
 pip install -r requirements.txt
 uvicorn main:app --reload
+```
+
+### Running the crawler
+To populate the database from an external site use the `/crawl` endpoint or run
+the helper script:
+
+```bash
+python crawler.py https://example.com
 ```
 
 ## Running 24/7

--- a/crawler.py
+++ b/crawler.py
@@ -1,0 +1,67 @@
+from collections import deque
+from urllib.parse import urljoin, urlparse
+from uuid import uuid4
+import datetime
+import random
+import requests
+from bs4 import BeautifulSoup
+
+from database import Database
+
+
+def generate_bi_id():
+    date_str = datetime.datetime.now().strftime("%Y%m%d")
+    random_suffix = f"{random.randint(1000, 9999)}"
+    return f"BIZ-TZ-{date_str}-{random_suffix}"
+
+
+def crawl_site(start_url: str, db: Database, max_pages: int = 5) -> int:
+    """Basic breadth-first crawler that stores discovered businesses."""
+    visited = set()
+    queue = deque([start_url])
+    added = 0
+
+    while queue and len(visited) < max_pages:
+        url = queue.popleft()
+        if url in visited:
+            continue
+        visited.add(url)
+        try:
+            resp = requests.get(url, timeout=5)
+            resp.raise_for_status()
+        except Exception:
+            continue
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        for tag in soup.select("[data-biz-name]"):
+            name = tag.get("data-biz-name") or tag.get_text(strip=True)
+            biz_id = str(uuid4())
+            db.add_business(
+                type("Biz", (), {
+                    "id": biz_id,
+                    "name": name,
+                    "bi_id": generate_bi_id(),
+                    "region": None,
+                    "sector": None,
+                    "digital_score": None,
+                    "formality": None,
+                    "premium": False,
+                    "verified": False,
+                    "claimed": False,
+                })
+            )
+            added += 1
+
+        for link in soup.find_all("a", href=True):
+            next_url = urljoin(url, link["href"])
+            if urlparse(next_url).netloc == urlparse(start_url).netloc and next_url not in visited:
+                queue.append(next_url)
+
+    return added
+
+
+if __name__ == "__main__":
+    db = Database()
+    count = crawl_site("https://example.com", db, max_pages=1)
+    print(f"Discovered {count} businesses")

--- a/database.py
+++ b/database.py
@@ -1,0 +1,149 @@
+import sqlite3
+from typing import Optional
+from contextlib import contextmanager
+
+class Database:
+    def __init__(self, path: str = "bizinteltz.db"):
+        self.path = path
+        self._init_db()
+
+    @contextmanager
+    def connection(self):
+        conn = sqlite3.connect(self.path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+    def _init_db(self):
+        with self.connection() as conn:
+            c = conn.cursor()
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS businesses (
+                    id TEXT PRIMARY KEY,
+                    name TEXT,
+                    bi_id TEXT UNIQUE,
+                    region TEXT,
+                    sector TEXT,
+                    digital_score INTEGER,
+                    formality TEXT,
+                    premium INTEGER,
+                    verified INTEGER,
+                    claimed INTEGER
+                )"""
+            )
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS reviews (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    business_id TEXT,
+                    rating INTEGER,
+                    comment TEXT
+                )"""
+            )
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS claims (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    business_id TEXT,
+                    owner_name TEXT,
+                    contact TEXT,
+                    approved INTEGER
+                )"""
+            )
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS analytics (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    business_id TEXT,
+                    action TEXT
+                )"""
+            )
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS leads (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    business_id TEXT,
+                    name TEXT,
+                    message TEXT
+                )"""
+            )
+            c.execute(
+                """CREATE TABLE IF NOT EXISTS media (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    business_id TEXT,
+                    filename TEXT
+                )"""
+            )
+            conn.commit()
+
+    def add_business(self, biz):
+        with self.connection() as conn:
+            conn.execute(
+                """INSERT OR REPLACE INTO businesses(
+                    id, name, bi_id, region, sector, digital_score, formality,
+                    premium, verified, claimed
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    biz.id,
+                    biz.name,
+                    biz.bi_id,
+                    biz.region,
+                    biz.sector,
+                    biz.digital_score,
+                    biz.formality,
+                    int(biz.premium),
+                    int(biz.verified),
+                    int(biz.claimed),
+                ),
+            )
+            conn.commit()
+
+    def delete_business(self, biz_id: str):
+        with self.connection() as conn:
+            conn.execute("DELETE FROM businesses WHERE id=?", (biz_id,))
+            conn.commit()
+
+    def add_review(self, review):
+        with self.connection() as conn:
+            conn.execute(
+                "INSERT INTO reviews(business_id, rating, comment) VALUES (?, ?, ?)",
+                (review.business_id, review.rating, review.comment),
+            )
+            conn.commit()
+
+    def add_claim(self, claim):
+        with self.connection() as conn:
+            conn.execute(
+                "INSERT INTO claims(business_id, owner_name, contact, approved) VALUES (?, ?, ?, ?)",
+                (claim.business_id, claim.owner_name, claim.contact, int(claim.approved)),
+            )
+            conn.commit()
+
+    def approve_claim(self, claim):
+        with self.connection() as conn:
+            conn.execute(
+                "UPDATE claims SET approved=1 WHERE business_id=? AND owner_name=? AND contact=?",
+                (claim.business_id, claim.owner_name, claim.contact),
+            )
+            conn.commit()
+
+    def add_event(self, event):
+        with self.connection() as conn:
+            conn.execute(
+                "INSERT INTO analytics(business_id, action) VALUES (?, ?)",
+                (event.business_id, event.action),
+            )
+            conn.commit()
+
+    def add_lead(self, lead):
+        with self.connection() as conn:
+            conn.execute(
+                "INSERT INTO leads(business_id, name, message) VALUES (?, ?, ?)",
+                (lead.business_id, lead.name, lead.message),
+            )
+            conn.commit()
+
+    def add_media(self, biz_id: str, filename: str):
+        with self.connection() as conn:
+            conn.execute(
+                "INSERT INTO media(business_id, filename) VALUES (?, ?)",
+                (biz_id, filename),
+            )
+            conn.commit()


### PR DESCRIPTION
## Summary
- add `database.py` with SQLite tables and helper methods
- store business data in SQLite from API actions
- add `crawler.py` example crawler and `/crawl` endpoint
- update README with persistence and crawler instructions

## Testing
- `python -m py_compile main.py database.py crawler.py`


------
https://chatgpt.com/codex/tasks/task_e_6862b5970c6c8321b2e82431a8d19a8b