### PR TITLE
Add features page and expose metrics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import AIMarketingAssistant from './pages/AIMarketingAssistant'
 import SkillBuilding from './pages/SkillBuilding'
 import CrawlerManagement from './pages/CrawlerManagement'
 import Rankings from './pages/Rankings'
+import Features from './pages/Features'
 import Login from './pages/Login'
 import ProtectedRoute from './components/ProtectedRoute'
 
@@ -43,6 +44,7 @@ function App() {
         <Route path="/business/:id" element={<BusinessProfile />} />
         <Route path="/verify" element={<BIVerification />} />
         <Route path="/rankings" element={<Rankings />} />
+        <Route path="/features" element={<Features />} />
         <Route path="/login" element={<Login />} />
         <Route path="/create-business" element={<CreateBusiness />} />
         <Route

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -90,12 +90,22 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
               <Link
                 to="/verify"
                 className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-                  isActive('/verify') 
-                    ? 'bg-primary-100 text-primary-700' 
+                  isActive('/verify')
+                    ? 'bg-primary-100 text-primary-700'
                     : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
                 }`}
               >
                 Verify BI ID
+              </Link>
+              <Link
+                to="/features"
+                className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  isActive('/features')
+                    ? 'bg-primary-100 text-primary-700'
+                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                }`}
+              >
+                Features
               </Link>
               
               {/* Intelligence Dropdown */}
@@ -343,6 +353,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 <li><Link to="/rankings" className="hover:text-gray-900 transition-colors">Rankings</Link></li>
                 <li><Link to="/search" className="hover:text-gray-900 transition-colors">Search Businesses</Link></li>
                 <li><Link to="/verify" className="hover:text-gray-900 transition-colors">Verify BI ID</Link></li>
+                <li><Link to="/features" className="hover:text-gray-900 transition-colors">All Features</Link></li>
                 <li><Link to="/create-business" className="hover:text-gray-900 transition-colors">Add Business</Link></li>
               </ul>
             </div>

--- a/src/pages/Features.tsx
+++ b/src/pages/Features.tsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Search,
+  Globe,
+  Download,
+  FileText,
+  Star,
+  Crown,
+  Shield,
+  BarChart3,
+  Upload,
+  Mail,
+  Lock,
+  Pencil
+} from 'lucide-react'
+
+interface Feature {
+  title: string
+  description: string
+  icon: React.FC<any>
+  link: string
+}
+
+const features: Feature[] = [
+  {
+    title: 'Advanced Search & Filtering',
+    description: 'Find businesses quickly using multiple filters.',
+    icon: Search,
+    link: '/search'
+  },
+  {
+    title: 'Region-wide Scraping',
+    description: 'Generate sample data across Tanzania.',
+    icon: Globe,
+    link: '/admin'
+  },
+  {
+    title: 'CSV Data Export',
+    description: 'Download business data as CSV files.',
+    icon: Download,
+    link: '/search'
+  },
+  {
+    title: 'Public Business Profiles',
+    description: 'Detailed profiles with reviews and media.',
+    icon: FileText,
+    link: '/search'
+  },
+  {
+    title: 'Reviews & Ratings',
+    description: 'Share feedback on businesses you use.',
+    icon: Star,
+    link: '/search'
+  },
+  {
+    title: 'Premium Listings',
+    description: 'Highlight top businesses for more visibility.',
+    icon: Crown,
+    link: '/admin'
+  },
+  {
+    title: 'Business Claiming',
+    description: 'Owners can claim and manage listings.',
+    icon: Shield,
+    link: '/search'
+  },
+  {
+    title: 'Analytics Tracking',
+    description: 'Monitor views and clicks for each business.',
+    icon: BarChart3,
+    link: '/admin/analytics'
+  },
+  {
+    title: 'Media Uploads',
+    description: 'Add images or videos to business profiles.',
+    icon: Upload,
+    link: '/search'
+  },
+  {
+    title: 'Lead Generation',
+    description: 'Send inquiries directly to businesses.',
+    icon: Mail,
+    link: '/search'
+  },
+  {
+    title: 'Website Crawling',
+    description: 'Crawl websites to discover more businesses.',
+    icon: Globe,
+    link: '/admin/crawler'
+  },
+  {
+    title: 'Authentication',
+    description: 'Secure access for administrators.',
+    icon: Lock,
+    link: '/login'
+  },
+  {
+    title: 'Manage Businesses',
+    description: 'Create, edit or remove business listings.',
+    icon: Pencil,
+    link: '/admin'
+  }
+]
+
+const Features: React.FC = () => (
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-8">
+    <div className="text-center space-y-3">
+      <h1 className="text-3xl font-bold text-gray-900">Platform Features</h1>
+      <p className="text-gray-600">Explore everything BizIntelTZ offers.</p>
+    </div>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      {features.map((feat, idx) => (
+        <Link
+          key={idx}
+          to={feat.link}
+          className="card p-6 flex items-start space-x-4 hover:shadow-md transition"
+        >
+          <feat.icon className="h-8 w-8 text-primary-600 flex-shrink-0" />
+          <div>
+            <h3 className="text-lg font-semibold text-gray-900 mb-1">{feat.title}</h3>
+            <p className="text-sm text-gray-600">{feat.description}</p>
+          </div>
+        </Link>
+      ))}
+    </div>
+  </div>
+)
+
+export default Features

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -147,7 +147,7 @@ const Home: React.FC = () => {
     totalBusinesses: '250,000+',
     verifiedEntities: '180,000+',
     monthlyVerifications: '45,000+',
-    dataPoints: '50M+',
+    dataPoints: '2M+',
     regions: '31',
     sectors: '120+',
     lastUpdate: new Date().toLocaleTimeString(),
@@ -281,7 +281,7 @@ const Home: React.FC = () => {
               </p>
               
               {/* Stats grid */}
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
                 <div className="bg-white/10 backdrop-blur-sm border border-white/10 rounded-lg p-3 hover:bg-white/15 transition-colors">
                   <div className="text-xl font-bold text-white">{realTimeMetrics?.totalBusinesses || '250,000+'}</div>
                   <div className="text-xs text-slate-300">Verified Entities</div>
@@ -293,6 +293,10 @@ const Home: React.FC = () => {
                 <div className="bg-white/10 backdrop-blur-sm border border-white/10 rounded-lg p-3 hover:bg-white/15 transition-colors">
                   <div className="text-xl font-bold text-white">{realTimeMetrics?.monthlyVerifications || '45,000+'}</div>
                   <div className="text-xs text-slate-300">Monthly Verifications</div>
+                </div>
+                <div className="bg-white/10 backdrop-blur-sm border border-white/10 rounded-lg p-3 hover:bg-white/15 transition-colors">
+                  <div className="text-xl font-bold text-white">{realTimeMetrics?.dataPoints || '2M+'}</div>
+                  <div className="text-xs text-slate-300">Data Points</div>
                 </div>
                 <div className="bg-white/10 backdrop-blur-sm border border-white/10 rounded-lg p-3 hover:bg-white/15 transition-colors">
                   <div className="text-xl font-bold text-white">{realTimeMetrics?.responseTime || '< 200ms'}</div>


### PR DESCRIPTION
## Summary
- add new Features page showing all major capabilities
- link Features page in navigation and footer
- expose metrics for total data points on the home page
- add route for Features page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6862d3784e9c8321acb31dc64185f918